### PR TITLE
udapte:调整取得自定义报表存储器的方式，在不影响原Spring Bean方式情况下，可以兼容其他框架如nutz

### DIFF
--- a/ureport2-core/src/main/java/com/bstek/ureport/Utils.java
+++ b/ureport2-core/src/main/java/com/bstek/ureport/Utils.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import com.bstek.ureport.provider.report.ReportProvider;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
@@ -46,6 +47,7 @@ public class Utils implements ApplicationContextAware{
 	private static ApplicationContext applicationContext;
 	private static Collection<BuildinDatasource> buildinDatasources;
 	private static Collection<ImageProvider> imageProviders;
+	private static Collection<ReportProvider> reportProviders;
 	private static boolean debug;
 	
 	public static boolean isDebug() {
@@ -70,7 +72,10 @@ public class Utils implements ApplicationContextAware{
 		return imageProviders;
 	}
 
-	
+	public static Collection<ReportProvider> getReportProviders() {
+		return reportProviders;
+	}
+
 	public static Connection getBuildinConnection(String name){
 		for(BuildinDatasource datasource:buildinDatasources){
 			if(name.equals(datasource.name())){
@@ -223,5 +228,7 @@ public class Utils implements ApplicationContextAware{
 		buildinDatasources.addAll(applicationContext.getBeansOfType(BuildinDatasource.class).values());
 		imageProviders=new ArrayList<ImageProvider>();
 		imageProviders.addAll(applicationContext.getBeansOfType(ImageProvider.class).values());
+		reportProviders=new ArrayList<ReportProvider>();
+		reportProviders.addAll(applicationContext.getBeansOfType(ReportProvider.class).values());
 	}
 }

--- a/ureport2-core/src/main/java/com/bstek/ureport/export/ReportRender.java
+++ b/ureport2-core/src/main/java/com/bstek/ureport/export/ReportRender.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import com.bstek.ureport.Utils;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -42,10 +43,9 @@ import com.bstek.ureport.provider.report.ReportProvider;
  * @author Jacky.gao
  * @since 2016年12月4日
  */
-public class ReportRender implements ApplicationContextAware{
+public class ReportRender {
 	private ReportParser reportParser;
 	private ReportBuilder reportBuilder;
-	private Collection<ReportProvider> reportProviders;
 	private DownCellbuilder downCellParentbuilder=new DownCellbuilder();
 	private RightCellbuilder rightCellParentbuilder=new RightCellbuilder();
 	public Report render(String file,Map<String,Object> parameters){
@@ -102,7 +102,7 @@ public class ReportRender implements ApplicationContextAware{
 	
 	private InputStream buildReportFile(String file){
 		InputStream inputStream=null;
-		for(ReportProvider provider:reportProviders){
+		for(ReportProvider provider:Utils.getReportProviders()){
 			if(file.startsWith(provider.getPrefix())){
 				inputStream=provider.loadReport(file);
 			}
@@ -137,8 +137,5 @@ public class ReportRender implements ApplicationContextAware{
 	public void setReportBuilder(ReportBuilder reportBuilder) {
 		this.reportBuilder = reportBuilder;
 	}
-	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		reportProviders=applicationContext.getBeansOfType(ReportProvider.class).values();
-	}
+
 }


### PR DESCRIPTION
解决在不使用spring的架构中无法修改自定义报表存储器的方式